### PR TITLE
Upgrade to net6

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -70,7 +70,7 @@ class Build : NukeBuild
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
                 .AddLoggers("trx")
-                .SetTestAdapterPath(SourceDirectory / "GitHubStatusChecksWebApp.Tests" / "bin" / Configuration.ToString() / "net5.0")
+                .SetTestAdapterPath(SourceDirectory / "GitHubStatusChecksWebApp.Tests" / "bin" / Configuration.ToString() / "net6.0")
                 .EnableNoBuild()
                 .EnableNoRestore());
         });

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.303",
+    "version": "6.0.102",
     "rollForward": "latestFeature"
   }
 }

--- a/source/GitHubStatusChecks.sln
+++ b/source/GitHubStatusChecks.sln
@@ -6,6 +6,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHubStatusChecksWebApp.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.csproj", "{374E2396-1273-44AF-B7A6-34E3260BEBA5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "terraform", "terraform", "{F370CDE8-C6A2-41D5-9ACC-1D2BFCE5F70A}"
+	ProjectSection(SolutionItems) = preProject
+		..\terraform\main.tf = ..\terraform\main.tf
+		..\terraform\octopus.auto.tfvars = ..\terraform\octopus.auto.tfvars
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/source/GitHubStatusChecksWebApp.Tests/GitHubStatusChecksWebApp.Tests.csproj
+++ b/source/GitHubStatusChecksWebApp.Tests/GitHubStatusChecksWebApp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <RootNamespace>GitHubStatusChecksWebApp.Tests</RootNamespace>
     </PropertyGroup>

--- a/source/GitHubStatusChecksWebApp/GitHubStatusChecksWebApp.csproj
+++ b/source/GitHubStatusChecksWebApp/GitHubStatusChecksWebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>GitHubStatusChecksWebApp</RootNamespace>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,7 +66,7 @@ resource "azurerm_app_service" "web" {
   https_only          = true
 
   site_config {
-    dotnet_framework_version = "v5.0"
+    dotnet_framework_version = "v6.0"
   }
 }
 
@@ -80,7 +80,7 @@ resource "azurerm_app_service_certificate" "ssl" {
 
 resource "azurerm_app_service_custom_hostname_binding" "web" {
   count               = var.environment == "Production" ? 1 : 0
-  hostname            = "githubstatuschecks.octopushq.com" 
+  hostname            = "githubstatuschecks.octopushq.com"
   app_service_name    = azurerm_app_service.web.name
   resource_group_name = azurerm_app_service.web.resource_group_name
   ssl_state           = "SniEnabled"


### PR DESCRIPTION
Upgrades to net6.0.

Our builds now use the mcr.microsoft.com/dotnet/sdk:6.0 container.
We'll have to tweak something in the azure portal, as the terraform doesn't apply the `v6.0` change properly.