### PR TITLE
Adds documentation status check

### DIFF
--- a/source/GitHubStatusChecksWebApp.Tests/DocumentationChainStatusRuleChecksFixture.cs
+++ b/source/GitHubStatusChecksWebApp.Tests/DocumentationChainStatusRuleChecksFixture.cs
@@ -1,0 +1,25 @@
+﻿using System.Linq;
+using GitHubStatusChecksWebApp.Rules;
+using NUnit.Framework;
+using Octokit;
+using Shouldly;
+
+namespace GitHubStatusChecksWebApp.Tests;
+
+[TestFixture]
+public class DocumentationChainStatusRuleChecksFixture
+{
+    [Test]
+    [TestCase(new [] {"newportal/jsfile.js", "newportal/readme.md"}, false)]
+    [TestCase(new [] {"newportal/readme.md"}, true)]
+    [TestCase(new [] {"source/Octopus.Server/csfile.cs", "readme.md"}, false)]
+    [TestCase(new [] {"otherfile.ps1"}, false)]
+    [TestCase(new [] {"newportal/readme.md", "readme.md"}, true)]
+    public void RulesValidate(string[] fileNames, bool shouldMatch)
+    {
+        var files = fileNames.Select(fileName => new PullRequestFile("", fileName, "", 0, 0, 0, "", "", "", "", "")).ToList();
+
+        var rule = new DocumentationChainStatusRuleChecks();
+        rule.MatchesRules(files).ShouldBe(shouldMatch);
+    }
+}

--- a/source/GitHubStatusChecksWebApp/Rules/DocumentationChainStatusRuleChecks.cs
+++ b/source/GitHubStatusChecksWebApp/Rules/DocumentationChainStatusRuleChecks.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using DotNet.Globbing;
+using Octokit;
+
+namespace GitHubStatusChecksWebApp.Rules;
+
+public class DocumentationChainStatusRuleChecks : IStatusCheck
+{
+    public string GetContext() => "Chain: Documentation";
+        
+    public bool MatchesRules(IEnumerable<PullRequestFile> files)
+    {
+        var glob = Glob.Parse("**/*.md");
+
+        return files.All(file => glob.IsMatch(file.FileName));
+    }
+}

--- a/source/GitHubStatusChecksWebApp/Rules/DocumentationChainStatusRuleChecks.cs
+++ b/source/GitHubStatusChecksWebApp/Rules/DocumentationChainStatusRuleChecks.cs
@@ -7,7 +7,7 @@ namespace GitHubStatusChecksWebApp.Rules;
 
 public class DocumentationChainStatusRuleChecks : IStatusCheck
 {
-    public string GetContext() => "Chain: Documentation";
+    public string GetContext() => "Chain: Documentation \\(Octopus Server .*\\)";
         
     public bool MatchesRules(IEnumerable<PullRequestFile> files)
     {

--- a/source/GitHubStatusChecksWebApp/Startup.cs
+++ b/source/GitHubStatusChecksWebApp/Startup.cs
@@ -48,6 +48,7 @@ namespace GitHubStatusChecksWebApp
                 c.SwaggerDoc("v1", new OpenApiInfo {Title = "GitHubStatusChecksWebApp", Version = "v1"});
             });
 
+            services.AddScoped<IStatusCheck, DocumentationChainStatusRuleChecks>();
             services.AddScoped<IStatusCheck, FrontEndChainStatusRuleChecks>();
             services.AddScoped<IStatusCheck, FullChainStatusRulesCheck>();
             services.AddScoped<GitHubStatusClient>();


### PR DESCRIPTION
We want to be able to get a 🟢 "build" for PRs that only modify documentation - md files in our case.

This PR introduces a new check that will work for a `Chain: Documentation` build configuration, and pass if all files in the PR are markdown files (and ONLY if all files are).