### PR TITLE
Update CODEOWNERS as part of engprod -> core platform handover

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @OctopusDeploy/team-engprod
+* @OctopusDeploy/team-core-platform-productivity


### PR DESCRIPTION
Setting _team-core-platform-productivity_ as the code owners for the time being. Perhaps worth expanding to the full core platform team when things settle, but we're handling the initial handover.